### PR TITLE
Interop profile generation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -53,6 +53,14 @@ def pytest_addoption(parser):
         help='Run tests matching SELECT_REGEX. '
         'Overrides tests selected in configuration.'
     )
+    group.addoption(
+        "-O",
+        "--output",
+        dest="save_path",
+        action="store",
+        metavar="PATH",
+        help="Save interop profile to PATH."
+    )
 
 
 @pytest.hookimpl(trylast=True)
@@ -71,6 +79,7 @@ def pytest_configure(config):
         config.suite_config = load_config(config_path)
     except FileNotFoundError:
         config.suite_config = default()
+    config.suite_config['save_path'] = config.getoption('save_path')
 
     # register additional markers
     config.addinivalue_line(
@@ -190,6 +199,9 @@ def report(config):
     """Report fixture."""
     report_instance = ReportSingleton(config)
     yield report_instance
+    save_path = config.get('save_path')
+    if save_path:
+        report_instance.save(save_path)
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -159,10 +159,7 @@ def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
 
-    if not hasattr(item, 'reports'):
-        setattr(item, 'reports', {})
-    item.reports[report.when] = report
-    # setattr(item, "report_" + report.when, report)
+    setattr(item, "report_" + report.when, report)
 
     term_reporter = item.config.pluginmanager.get_plugin('terminalreporter')
     if report.when == 'call' and report.failed:

--- a/conftest.py
+++ b/conftest.py
@@ -182,6 +182,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     terminalreporter.write_sep('=', 'Interop Profile', bold=True, yellow=True)
     terminalreporter.write('\n')
     terminalreporter.write(ReportSingleton(config.suite_config).to_json())
+    terminalreporter.write('\n')
 
 
 @pytest.fixture(scope='session')

--- a/protocol_tests/__init__.py
+++ b/protocol_tests/__init__.py
@@ -86,7 +86,7 @@ class ChannelManager(StaticConnection):
         appropriate frontchannels.
         """
         for recipient in _recipients_from_packed_message(packed_message):
-            if recipient == self.test_suite_vk:
+            if recipient == self.my_vk_b58:
                 await super().handle(packed_message)
             if recipient in self.frontchannels:
                 await self.frontchannels[recipient].handle(packed_message)

--- a/protocol_tests/connection/test_manual.py
+++ b/protocol_tests/connection/test_manual.py
@@ -7,7 +7,8 @@ import uuid
 from schema import Optional
 import pytest
 
-from aries_staticagent import StaticConnection, Message, crypto
+from aries_staticagent import Message, crypto
+from reporting import meta
 from .. import MessageSchema
 
 DIDDOC_SCHEMA = MessageSchema({
@@ -49,7 +50,6 @@ REQUEST_SCHEMA = MessageSchema({
     }
 })
 
-
 RESPONSE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response'
 RESPONSE_SCHEMA_PRE_SIG_VERIFY = MessageSchema({
     '@type': RESPONSE,
@@ -87,6 +87,7 @@ def parse_invite(invite_url: str) -> Message:
     INVITE_SCHEMA.validate(invite_msg)
 
     return invite_msg
+
 
 def build_invite(label: str, connection_key: str, endpoint: str) -> str:
     msg = Message({
@@ -177,8 +178,9 @@ def build_response(
 @pytest.mark.features("core.manual", "connection.manual")
 @pytest.mark.priority(10)
 @pytest.mark.asyncio
+@meta(protocol='connections', version='1.0', role='inviter', name='can-start')
 async def test_connection_started_by_tested_agent(config, temporary_channel):
-    """ Test a connection as started by the agent under test """
+    """Test a connection as started by the agent under test."""
     invite_url = input('Input generated connection invite: ')
 
     invite_msg = parse_invite(invite_url)
@@ -235,6 +237,7 @@ async def test_connection_started_by_tested_agent(config, temporary_channel):
 @pytest.mark.features("core.manual", "connection.manual")
 @pytest.mark.priority(10)
 @pytest.mark.asyncio
+@meta(protocol='connections', version='1.0', role='invitee', name='can-receive')
 async def test_connection_started_by_suite(config, temporary_channel):
     """ Test a connection as started by the suite. """
 

--- a/protocol_tests/test_simple_messaging.py
+++ b/protocol_tests/test_simple_messaging.py
@@ -1,6 +1,4 @@
 """ Demonstrate testing framework. """
-import asyncio
-# import logging
 
 import pytest
 
@@ -9,13 +7,15 @@ from aries_staticagent.mtc import (
     CONFIDENTIALITY, INTEGRITY, AUTHENTICATED_ORIGIN,
     DESERIALIZE_OK, NONREPUDIATION
 )
+from reporting import meta
 from . import MessageSchema
 
 
 @pytest.mark.asyncio
 @pytest.mark.features('simple')
+@meta(protocol='simple', version='0.1', role='*', name='simple')
 async def test_simple_messaging(backchannel):
-    """ Show simple messages being passed to and from the test subject """
+    """Show simple messages being passed to and from the test subject."""
 
     expected_schema = MessageSchema({
         '@type': 'test/protocol/1.0/test',

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 log_cli=true
 log_cli_level=warn
+usefixtures=report_on_test

--- a/reporting.py
+++ b/reporting.py
@@ -59,24 +59,27 @@ class TestReport:
 
     def flatten(self):
         """Flatten this TestReport object into dictionary."""
-        return {
-            'name': ','.join([
-                self.function.protocol,
-                self.function.version,
-                self.function.role,
-                self.function.name
-            ]),
-            'description': self.function.description,
-            'pass': self.report.outcome == 'passed',
-            'info': self.report.longrepr,
-            'warnings': list(map(
-                lambda warning: {
-                    'message': warning.message,
-                    'category': warning.category.__name__
-                },
-                self.warnings
-            )),
-        }
+        return dict(filter(
+            lambda item: bool(item[1]),
+            {
+                'name': ','.join([
+                    self.function.protocol,
+                    self.function.version,
+                    self.function.role,
+                    self.function.name
+                ]),
+                'description': self.function.description,
+                'pass': self.report.outcome == 'passed',
+                'info': self.report.longrepr,
+                'warnings': list(map(
+                    lambda warning: {
+                        'message': warning.message,
+                        'category': warning.category.__name__
+                    },
+                    self.warnings
+                )),
+            }.items()
+        ))
 
 
 class Report:

--- a/reporting.py
+++ b/reporting.py
@@ -1,0 +1,132 @@
+"""Reporting for aries protocol tests."""
+import datetime
+import json
+from warnings import WarningMessage
+
+import _pytest
+from setup import VERSION
+
+# pylint: disable=too-few-public-methods
+
+
+def meta(
+        protocol: str = None,
+        version: str = None,
+        role: str = None,
+        name: str = None):
+    """Set meta information about test functions."""
+    def _meta(func):
+        func.protocol = protocol
+        func.version = version
+        func.role = role
+        func.name = name
+        return func
+    return _meta
+
+
+class TestFunction:
+    """Container for TestFunction information."""
+
+    __slots__ = ('protocol', 'version', 'role', 'name', 'description')
+
+    def __init__(  # pylint: disable=too-many-arguments
+            self,
+            protocol: str,
+            version: str,
+            role: str,
+            name: str,
+            description: str):
+        self.protocol = protocol
+        self.version = version
+        self.role = role
+        self.name = name
+        self.description = description
+
+
+class TestReport:
+    """Collection of information needed to report about a run test."""
+
+    __slots__ = ('function', 'report', 'warnings')
+
+    def __init__(
+            self,
+            function: TestFunction,
+            report: _pytest.runner.TestReport,
+            warnings: [WarningMessage]):
+        self.function = function
+        self.report = report
+        self.warnings = warnings
+
+    def flatten(self):
+        """Flatten this TestReport object into dictionary."""
+        return {
+            'name': ','.join([
+                self.function.protocol,
+                self.function.version,
+                self.function.role,
+                self.function.name
+            ]),
+            'description': self.function.description,
+            'pass': self.report.outcome == 'passed',
+            'info': self.report.longrepr,
+            'warnings': list(map(
+                lambda warning: {
+                    'message': warning.message,
+                    'category': warning.category.__name__
+                },
+                self.warnings
+            )),
+        }
+
+
+class Report:
+    """Protocol Test Suite report helper."""
+    # Meta information
+    TYPE = "Aries Test Suite Interop Profile v1"
+    VERSION = VERSION
+
+    def __init__(self, config: dict):
+        self.test_time = '{date:%Y-%m-%dT%H:%M:%S}'.format(
+            date=datetime.datetime.utcnow()
+        )
+        self.under_test_name = config['subject'].get('name', '')
+        self.under_test_version = config['subject'].get('version', '')
+        self.tests: [TestReport] = []
+
+    def add_report(self, report: TestReport):
+        """Append test report to tests list."""
+        self.tests.append(report)
+
+    def make_report(self) -> dict:
+        """Construct flat report dictionary."""
+        return {
+            '@type': Report.TYPE,
+            'suite_version': Report.VERSION,
+            'under_test_name': self.under_test_name,
+            'under_test_version': self.under_test_version,
+            'test_time': self.test_time,
+            'results': list(map(lambda tr: tr.flatten(), self.tests))
+        }
+
+    def to_json(self, pretty_print=True) -> str:
+        """Serialize report to string."""
+        if pretty_print:
+            return json.dumps(self.make_report(), indent=2)
+
+        return json.dumps(self.make_report)
+
+
+class ReportSingleton:
+    """Singleton for Report object."""
+    _instance = None
+
+    def __new__(cls, config):
+        if not ReportSingleton._instance:
+            ReportSingleton._instance = Report(config)
+        return ReportSingleton._instance
+
+    def __getattr__(self, name):
+        return getattr(self._instance, name)
+
+    def __setattr__(self, name, value):
+        return setattr(self._instance, name, value)

--- a/reporting.py
+++ b/reporting.py
@@ -113,7 +113,6 @@ class Report:
 
     def to_json(self, pretty_print=True) -> str:
         """Serialize report to string."""
-        print(self.make_report())
         if pretty_print:
             return json.dumps(self.make_report(), indent=2)
 

--- a/reporting.py
+++ b/reporting.py
@@ -118,6 +118,11 @@ class Report:
 
         return json.dumps(self.make_report)
 
+    def save(self, path):
+        """Save the test report out to a file."""
+        with open(path, 'w') as out_file:
+            json.dump(self.make_report(), out_file, indent=2)
+
 
 class ReportSingleton:
     """Singleton for Report object."""

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,15 @@
 
 from setuptools import setup, find_packages
 
+
 def parse_requirements(filename):
     """Load requirements from a pip requirements file."""
     lineiter = (line.strip() for line in open(filename))
     return [line for line in lineiter if line and not line.startswith("#")]
+
+
+VERSION = '0.1.0'
+
 
 if __name__ == '__main__':
     with open('README.md', 'r') as fh:
@@ -13,7 +18,7 @@ if __name__ == '__main__':
 
     setup(
         name='aries-protocol-test-suite',
-        version='0.1.0',
+        version=VERSION,
         author='Daniel Bluhm <daniel.bluhm@sovrin.org>',
         description='Suite for testing protocol compliance of Aries Agents',
         long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
Added support for creating interop profiles as defined in the test suite RFC. Sample output from the test suite:

```
...
Received Response (post signature verification):
 {
  "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response",
  "~thread": {
    "thid": "d333344f-4109-4307-98c1-be8f04024ceb",
    "sender_order": 0
  },
  "@id": "d8f4bc60-1363-4020-819f-a19f52772681",
  "connection": {
    "DID": "AWyQBgdZusu8Y3jGbmH3ma",
    "DIDDoc": {
      "@context": "https://w3id.org/did/v1",
      "id": "AWyQBgdZusu8Y3jGbmH3ma",
      "publicKey": [
        {
          "id": "AWyQBgdZusu8Y3jGbmH3ma#keys-1",
          "type": "Ed25519VerificationKey2018",
          "controller": "AWyQBgdZusu8Y3jGbmH3ma",
          "publicKeyBase58": "6BqwHiKP4sAJRSPF6T8u7PFQYyKWiYQEbFerRVvqCoXz"
        }
      ],
      "service": [
        {
          "id": "AWyQBgdZusu8Y3jGbmH3ma;indy",
          "type": "IndyAgent",
          "recipientKeys": [
            "6BqwHiKP4sAJRSPF6T8u7PFQYyKWiYQEbFerRVvqCoXz"
          ],
          "routingKeys": [],
          "serviceEndpoint": "http://localhost:3001"
        }
      ]
    }
  }
}

protocol_tests/connection/test_manual.py::test_connection_started_by_tested_agent PASSED


==== Interop Profile ====

{
  "@type": "Aries Test Suite Interop Profile v1",
  "suite_version": "0.1.0",
  "under_test_name": "",
  "under_test_version": "",
  "test_time": "2019-11-06T20:36:46",
  "results": [
    {
      "name": "connections,1.0,inviter,can-start",
      "description": "Test a connection as started by the agent under test.",
      "pass": true,
      "info": null,
      "warnings": []
    }
  ]
}
==== 1 passed, 2 deselected in 10.81 seconds ====
```