### PR TITLE
Use voluptuous instead of schema for message schemas

### DIFF
--- a/protocol_tests/__init__.py
+++ b/protocol_tests/__init__.py
@@ -1,23 +1,101 @@
 """ Protocol Test Helpers """
-from typing import Dict, Iterable, Union
 from contextlib import contextmanager
+from functools import reduce
+from typing import Dict, Iterable, Union
+from warnings import warn
 import hashlib
 import json
 
-from schema import Schema
+from aries_staticagent import StaticConnection, crypto
 
-from aries_staticagent import StaticConnection, Message, crypto
+from voluptuous import Schema
+from voluptuous.error import Invalid, MultipleInvalid
 
 
-class MessageSchema():  # pylint: disable=too-few-public-methods
-    """ Wrap Schema for better message validation experience """
-    def __init__(self, schema_dict):
-        self._schema = Schema(schema_dict)
+class ValidationError(Exception):
+    """When errors on validation"""
+    def __init__(self, error: Invalid):
+        if isinstance(error, MultipleInvalid):
+            super().__init__(
+                'Multiple errors found during validation:\n\t' +
+                ('\n\t'.join(
+                    [
+                        str(error)
+                        for error in error.errors
+                    ]
+                ))
+            )
+        else:
+            super().__init__(
+                str(error)
+            )
 
-    def validate(self, msg: Message):
-        """ Validate message, storing defaults inserted by validation. """
-        msg.update(self._schema.validate(dict(msg)))
-        return msg
+
+class UnexceptedMessageKey(Warning):
+    """Warning raised when an unexpected property is found in a message."""
+
+
+def invalid_into_unexpected(error):
+    path = ' @ message[%s]' % ']['.join(map(repr, error.path)) \
+        if error.path else ''
+    warn(
+        'Unexpected Message key found{}'.format(path),
+        UnexceptedMessageKey
+    )
+
+
+def is_extra_key_error(error):
+    return error.error_message == 'extra keys not allowed'
+
+
+def MessageSchema(schema, warn_on_extra=True):
+    """
+    Wrap validation for messages to ensure they are passed as dictionaries.
+
+    Passing as messages results in errors as the validator attempts to mutate
+    nested objects into messages which fails when no `@type` attribute is
+    available.
+
+    Also wrap errors into collected Validation error and raise extra key errors
+    as warnings instead of exceptions.
+    """
+    __tracebackhide__ = True
+    validator = Schema(schema)
+
+    def _ensure_dict_and_validate(msg):
+        try:
+            return validator(dict(msg))
+        except MultipleInvalid as error:
+            def split(acc, error):
+                extra_errors, not_extra_errors = acc
+                if is_extra_key_error(error):
+                    extra_errors.append(error)
+                else:
+                    not_extra_errors.append(error)
+                return (extra_errors, not_extra_errors)
+
+            extra_errors, not_extra_errors = reduce(
+                split, error.errors, ([], [])
+            )
+
+            # Apply invalid_into_unexpected to each error for extra keys
+            list(map(invalid_into_unexpected, extra_errors))
+
+            if not_extra_errors:
+                # Re-raise the rest
+                raise ValidationError(
+                    MultipleInvalid(not_extra_errors)
+                )
+        except Invalid as error:
+            if warn_on_extra:
+                if is_extra_key_error(error):
+                    invalid_into_unexpected(error)
+                else:
+                    raise ValidationError(error)
+            else:
+                raise ValidationError(error)
+
+    return _ensure_dict_and_validate
 
 
 def _recipients_from_packed_message(packed_message: bytes) -> Iterable[str]:
@@ -37,7 +115,9 @@ def _recipients_from_packed_message(packed_message: bytes) -> Iterable[str]:
     except Exception as err:
         raise ValueError("Invalid packed message recipients") from err
 
-    return map(lambda recip: recip['header']['kid'], recips_outer['recipients'])
+    return map(
+        lambda recip: recip['header']['kid'], recips_outer['recipients']
+    )
 
 
 class ChannelManager(StaticConnection):

--- a/protocol_tests/connection/test_manual.py
+++ b/protocol_tests/connection/test_manual.py
@@ -4,13 +4,13 @@ import re
 import base64
 import uuid
 
-from schema import Optional
 import pytest
 
-from aries_staticagent import StaticConnection, Message, crypto
+from aries_staticagent import Message, crypto
+from voluptuous import Schema, Optional
 from .. import MessageSchema
 
-DIDDOC_SCHEMA = MessageSchema({
+DIDDOC_SCHEMA = Schema({
     "@context": "https://w3id.org/did/v1",
     "id": str,
     "publicKey": [{
@@ -84,7 +84,7 @@ def parse_invite(invite_url: str) -> Message:
         base64.urlsafe_b64decode(matches.group(2)).decode('ascii')
     )
 
-    INVITE_SCHEMA.validate(invite_msg)
+    INVITE_SCHEMA(invite_msg)
 
     return invite_msg
 
@@ -209,7 +209,7 @@ async def test_connection_started_by_tested_agent(config, temporary_channel):
             timeout=30
         )
 
-        RESPONSE_SCHEMA_PRE_SIG_VERIFY.validate(response)
+        RESPONSE_SCHEMA_PRE_SIG_VERIFY(response)
         print(
             "\nReceived Response (pre signature verification):\n",
             response.pretty_print()
@@ -220,7 +220,7 @@ async def test_connection_started_by_tested_agent(config, temporary_channel):
         assert signer == invite_msg['recipientKeys'][0], 'Unexpected signer'
         del response['connection~sig']
 
-        RESPONSE_SCHEMA_POST_SIG_VERIFY.validate(response)
+        RESPONSE_SCHEMA_POST_SIG_VERIFY(response)
         assert response['~thread']['thid'] == request.id
 
         print(
@@ -258,7 +258,7 @@ async def test_connection_started_by_suite(config, temporary_channel):
             timeout=30
         )
 
-        REQUEST_SCHEMA.validate(request)
+        REQUEST_SCHEMA(request)
         print("\nReceived request:\n", request.pretty_print())
 
         (_, conn.their_vk_b58, conn.endpoint) = (

--- a/reporting.py
+++ b/reporting.py
@@ -73,7 +73,7 @@ class TestReport:
                 'pass': self.passed,
                 'warnings': list(map(
                     lambda warning: {
-                        'message': warning.message,
+                        'message': str(warning.message),
                         'category': warning.category.__name__
                     },
                     self.warnings

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp
 aries-staticagent==0.5.1
 pytest
 pytest-asyncio
-schema
+voluptuous
 semver
 sortedcontainers
 toml


### PR DESCRIPTION
Voluptuous is very similar to the original schema library but comes with the benefit of validating the whole message and return all errors rather than throwing an error on the first failed validation.

Also included is raising warnings on unexpected keys in messages rather than failing validation.

Signed-off-by: Daniel Bluhm <daniel.bluhm@sovrin.org>