### PR TITLE
Test selection and listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ with:
 $ protocoltest
 ```
 
+To list available tests without running the test suite:
+```sh
+$ protocoltest --collect-only --list
+```
+
 Use `protocoltest --help` to see more options:
 ```
 Aries Protocol Test Suite Configuration:

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ Quickstart Guide
 ### Requirements
 
 - Python 3.6 or higher
-- `libindy` either installed as a package or compiled and placed in
-  `LD_LIBRARY_PATH`
-	- Follow instructions for your platform [here][1].
 
 ### Configuring and Running the Protocol Test Suite
 After cloning this repository, create and activate a virtual environment to
@@ -34,58 +31,26 @@ explaining each option:
 ## Aries Protocol Test Suite Sample Configuration ##
 
 [config]
-# The default name used for wallets created by the test agent.
-wallet = "testing-agent"
+# HTTP Server options
+host = "localhost"
+port = 3000
 
-# Passphrase of wallet
-passphrase = "test"
+# Endpoint reported to other agents
+endpoint = "http://localhost:3000"
 
-# Specify whether wallets should be ephemeral
-ephemeral = true
-
-# Endpoint used in connections
-endpoint = "http://localhost:3000/"
-
-# A list of features or protocols to test.
-features = [
-    "connection.manual",
-    #"simple"
-    #"basicmessage.manual",
-    #"trustping.manual"
+# List of regular expressions used to select tests.
+# If a test name matches at least one regex in this list, it will be selected
+# for execution.
+tests = [
+    "connections*",
 ]
 
-# Transports to run
-[[config.transport]]
-name = 'http'
-options = {port = 3000}
-
-# More transports can be started by including more transport blocks:
-# [[config.transport]]
-# name = 'ws'
-# options = {port = 3001}
-
-# Uncommenting this block would start a WebSocket transport on port 3001.
-# However, please note that an "http+ws" transport is included in the test
-# suite, removing any need to run both an "http" and "ws" transport at the same
-# time.
-
-# Four different transports are included in the test suite (with potential to
-# easily add more as needs are identified):
-
-# "http" - the same transport as included in this configuration. Accepts
-# messages as POSTs to http://<hostname>:<port>/
-
-# "ws" - A WebSocket transport, as shown in the commented out example above.
-# This transport will accept WebSocket connections at http://<hostname>:<port>/
-
-# "http+ws" - A Combined http and ws transport, running one server to accept
-# POSTs and WebSocket connections.
-
-# "std" - A transport that reads messages from Standard In and writes messages
-# to Standard Out. This is mostly included for demonstration purposes and likely
-# will not work with the current testing setup.
-
-# SNIP...
+[config.subject]
+# Name and version reported in interop profile
+name = "MyAgent"
+version = "1.0.0"
+# Endpoint used for backchannel
+endpoint="http://localhost:3001"
 ```
 
 Now that you have your configuration file, you can now run the test suite
@@ -94,35 +59,26 @@ with:
 $ protocoltest
 ```
 
-> _**Note:**_ if you are running tests labelled as "manual" (e.g.
-> `connection.manual`), you must include the `-s` option.
-
-`protocoltest` is installed into your `PATH` when you run `pip install -e .`. If
-running `protocoltest` doesn't work, it means you skipped that step. You can
-alternatively run the script directly:
-
-```sh
-$ scripts/protocoltest
+Use `protocoltest --help` to see more options:
 ```
-
-Use `protocoltest --help` to see more options.
-
-[1]: https://github.com/hyperledger/indy-sdk#installing-the-sdk
+Aries Protocol Test Suite Configuration:
+  --sc=SUITE_CONFIG, --suite-config=SUITE_CONFIG
+                        Load suite configuration from SUITE_CONFIG
+  -S SELECT_REGEX, --select=SELECT_REGEX
+                        Run tests matching SELECT_REGEX. Overrides tests
+                        selected in configuration.
+  -O PATH, --output=PATH
+                        Save interop profile to PATH.
+  -L, --list            List available tests.
+```
 
 Writing Tests
 -------------
-
-A simple example of writing a test using the test suite can be found in
-[`test_simple_messaging.py`][3]. This test statically connects to another agent
-(i.e. it receives the DID, key, and endpoint needed to communicate through
-configuration rather than through engaging in a message exchange) and
-demonstrates that the two can communicate.
-
-As seen in this example, the test suite and the testing framework provide
-several helpers as documented below.
+A simple example of a protocol test can be found in
+[`test_simple_messaging.py`][3]. This test uses the test suite backchannel to
+send and receive a simple test ping message and response.
 
 ### Async Tests
-
 Tests follow standard `pytest` conventions. However, due to the asynchronous
 nature of messaging and SDK calls, most tests will likely need to `await` a
 promise and must be marked as asynchronous, e.g.:
@@ -133,18 +89,14 @@ async def test_method():
 	await some_async_call()
 ```
 
-### Marking Features
-
-Tests are grouped as "features" to meaningfully group functionality. For
-instance, a group of tests or feature can be created to show that an agent is
-capable of fulfilling at least one role of a protocol.
-
-Assigning tests to features is done through `pytest` marks. A single test can be
-marked with an annotation:
+### Assigning Test Meta Information
+Tests are assigned meta information to help with test selection and
+interoperability profile reporting. To assign meta information to a test, use
+the `meta` decorator from the [`reporting`](reporting.py) module:
 
 ```python
 @pytest.mark.asyncio
-@pytest.mark.features('my_feature')
+@meta(protocol='test', version='1.0', role='initiator', name='test-this')
 async def test_method():
 	await some_async_call()
 ```
@@ -157,164 +109,3 @@ Multiple features can be assigned with a single mark:
 async def test_method():
 	await some_async_call()
 ```
-
-A python class can also be marked in the same manner, allowing all tests
-belonging to that class to be marked with a single annotation:
-
-```python
-
-@pytest.mark.features('my_feature')
-class MyTestClass:
-
-	@pytest.mark.asyncio
-	async def test_method_marked_with_my_feature(self):
-		await some_async_call()
-
-	@pytest.mark.asyncio
-	async def test_another_method_also_marked_with_my_feature(self):
-		await some_async_call()
-```
-
-Python modules can be marked by setting the `pytestmark` variable at the root of
-the module:
-
-```python
-
-pytestmark = [
-	pytest.mark.features('my_feature')
-]
-
-
-@pytest.mark.asyncio
-async def test_method_marked_with_my_feature():
-	await some_async_call()
-
-@pytest.mark.asyncio
-async def test_another_method_also_marked_with_my_feature():
-	await some_async_call()
-```
-
-### Test Ordering
-
-In some cases it is useful to explicitly order test execution. This ordering
-does not represent dependencies in the tests themselves but rather just an
-ordering that logically follows; for example, tests for a connection protocol
-may be configured to execute first as an agent that fails to connect is unlikely
-to pass later tests.
-
-Tests are ordered based on priority where higher priorities occur first.
-Priority is set using a `pytest` mark. Setting priority follows the same rules
-for tests, classes, and modules as noted above in [Marking
-Fixtures](#Marking-Fixtures).
-
-Example:
-
-```python
-@pytest.mark.asyncio
-@pytest.mark.features('my_feature')
-@pytest.mark.priority(10)
-async def test_method():
-	await some_async_call()
-```
-
-The above test will be executed strictly after all tests with priority greater
-than 10, in an undefined order (most likely alphabetical based on test name) for
-other tests with priority equal to 10, and strictly before tests with priority
-less than 10.
-
-### Fixtures and Agent
-
-#### Config
-
-`config` is a fixture that can be pulled into any test method by including
-`config` in the parameter list. This grants access to options configured in your
-`config.toml`.
-
-#### Agent
-
-`agent` is also a fixture that can be pulled into any test method by including
-`agent` in the parameter list. You will likely need `agent` for every test as
-this is how you will interacted with the agent under test. The agent fixture
-does _not_ refer to the agent you're testing but rather to the agent internal to
-the test suite. This agent holds a wallet, maintains transport level
-connections, and enables the sending and receiving of messages in the test
-suite.
-
-#### Agent Methods
-
-The following are methods of `agent` that will aid in testing.
-
-##### Agent.send
-
-Send an agent message to a specified recipient.
-
-- **Arguments:**
-	- `msg: Message` - the message to be sent
-	- `to_key: str` - the Verkey of the recipient
-
-- **Keyword Arguments:**
-	- `to_did: str` - the DID of the recipient
-	- `from_key: str` - the Verkey of the sender ("our Verkey"). Including this
-		argument results in an "auth-crypted" encryption envelope for the
-		message.  Omitting this argument results in an "anon-crypted" encryption
-		envelope.
-	- `service: dict` - A dictionary containing the service info of the intended
-		recipient. This is expected to contain a `serviceEndpoint` key-value
-		pair.
-
-- **Usage:** When only the required arguments are given, the agent attempts to look
-	up service information in the wallet from the `to_key`'s metadata. If a
-	`to_did` is given, the agent attempts to look up service information in the
-	wallet from the `to_did`'s metadata. If `service` is provided, that service
-	information is used and no look up is attempted in the wallet. Giving
-	`from_key` only affects whether the resulting message is "auth-" or
-	"anon-crypted."
-
-##### Agent.expect_message
-
-Wait for a message of a given type.
-
-- **Arguments:**
-	- `msg_type: str` - the type of message to wait for
-	- `timeout: int` - the number of seconds to wait
-- **Returns** `Message` - the message received
-
-##### Agent.sign_field
-
-Sign a field of a message.
-
-- **Arguments:**
-	- `my_vk: str` - the corresponding verkey of the sigkey to use to sign `field`
-	- `field: dict` - the field to sign
-- **Returns** `dict` - signed field
-
-##### Agent.unpack_signed_field
-
-Unpack a signed field.
-
-- **Arguments:**
-	- `signed_field: dict` - the output of `sign_field`
-- **Returns** `dict` - the field as it was before signing
-- **Usage:** this method asserts that the signature can be verified.
-
-##### Agent.ok
-
-Assert that nothing has halted in the test suite's agent.
-
-### Message Schemas
-
-The test suite makes use of a [flexible schema library][2] to define the
-expected structure of messages sent and received by the agent. The test suite
-provides a wrapper, `MessageSchema`, around these schemas to make use with agent
-messages more straightforward.
-
-`MessageSchema` can be found in [`protocol_tests/__init__.py`][4].
-
-For examples of how to use `MessageSchema`, see [`test_simple_messaging.py`][3]
-and [`connection/test_manual.py`][5].  Refer to [the documentation][2] for
-general usage of the Schema library.
-
-[2]: https://github.com/keleshev/schema
-[3]: protocol_tests/test_simple_messaging.py
-[4]: protocol_tests/__init__.py
-[5]: protocol_tests/connection/test_manual.py

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+"""Test Suite config."""
 import toml
 
 
@@ -15,5 +16,5 @@ def default():
         'subject': {
             'endpoint': 'http://localhost:3001'
         },
-        'features': []
+        'tests': []
     }

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,13 +1,23 @@
 ## Aries Protocol Test Suite Sample Configuration ##
 
 [config]
+# HTTP Server options
 host = "localhost"
 port = 3000
+
+# Endpoint reported to other agents
 endpoint = "http://localhost:3000"
 
+# List of regular expressions used to select tests.
+# If a test name matches at least one regex in this list, it will be selected
+# for execution.
 tests = [
     "connections*",
 ]
 
 [config.subject]
+# Name and version reported in interop profile
+name = "MyAgent"
+version = "1.0.0"
+# Endpoint used for backchannel
 endpoint="http://localhost:3001"

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -5,11 +5,8 @@ host = "localhost"
 port = 3000
 endpoint = "http://localhost:3000"
 
-features = [
-    "connection.manual",
-    #"simple"
-    #"basicmessage.manual",
-    #"trustping.manual"
+tests = [
+    "connections*",
 ]
 
 [config.subject]

--- a/conftest.py
+++ b/conftest.py
@@ -140,7 +140,13 @@ def pytest_collection_modifyitems(session, config, items):
             item_pipeline
         )
 
-    items[:] = list(item_pipeline)
+    remaining = list(item_pipeline)
+    deselected = set(items) - set(remaining)
+
+    # Report the deselected items to pytest
+    config.hook.pytest_deselected(items=deselected)
+
+    items[:] = remaining
 
 
 @pytest.hookimpl()

--- a/protocol_tests/connection/test_manual.py
+++ b/protocol_tests/connection/test_manual.py
@@ -175,8 +175,6 @@ def build_response(
     })
 
 
-@pytest.mark.features("core.manual", "connection.manual")
-@pytest.mark.priority(10)
 @pytest.mark.asyncio
 @meta(protocol='connections', version='1.0', role='inviter', name='can-start')
 async def test_connection_started_by_tested_agent(config, temporary_channel):
@@ -234,8 +232,6 @@ async def test_connection_started_by_tested_agent(config, temporary_channel):
         # to those disclosed in the response.
 
 
-@pytest.mark.features("core.manual", "connection.manual")
-@pytest.mark.priority(10)
 @pytest.mark.asyncio
 @meta(protocol='connections', version='1.0', role='invitee', name='can-receive')
 async def test_connection_started_by_suite(config, temporary_channel):

--- a/protocol_tests/connection/test_manual.py
+++ b/protocol_tests/connection/test_manual.py
@@ -235,7 +235,7 @@ async def test_connection_started_by_tested_agent(config, temporary_channel):
 @pytest.mark.asyncio
 @meta(protocol='connections', version='1.0', role='invitee', name='can-receive')
 async def test_connection_started_by_suite(config, temporary_channel):
-    """ Test a connection as started by the suite. """
+    """Test a connection as started by the suite."""
 
     with temporary_channel() as conn:
         invite_str = build_invite(

--- a/protocol_tests/test_simple_messaging.py
+++ b/protocol_tests/test_simple_messaging.py
@@ -12,7 +12,6 @@ from . import MessageSchema
 
 
 @pytest.mark.asyncio
-@pytest.mark.features('simple')
 @meta(protocol='simple', version='0.1', role='*', name='simple')
 async def test_simple_messaging(backchannel):
     """Show simple messages being passed to and from the test subject."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,2 @@
 [pytest]
-log_cli=true
-log_cli_level=warn
 usefixtures=report_on_test

--- a/scripts/apts
+++ b/scripts/apts
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+import sys
+import pytest
+
+pytest.main(['protocol_tests'] + sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
             'Operating System :: OS Independent'
         ],
         scripts=[
-            'scripts/protocoltest'
+            'scripts/protocoltest',
+            'scripts/apts'
         ]
     )


### PR DESCRIPTION
Select tests by test name (e.g. `connections,1.0,inviter,can-start`) and add listing option to command line arguments. Also includes some other minor tweaks such as keeping output brief when not capturing output, preventing interop report when using `--collect-only`, etc.

Sample test listing:

```sh
$ protocoltest --collect-only --list

Attempting to load configuration from file: .../aries-protocol-test-suite/config.toml

==== test session starts =====
platform linux -- Python 3.7.4, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
rootdir: .../aries-protocol-test-suite, inifile: pytest.ini
plugins: metadata-1.8.0, json-report-1.1.0, asyncio-0.10.0
collected 3 items
<Package .../aries-protocol-test-suite/protocol_tests>
  <Module test_simple_messaging.py>
    <Function test_simple_messaging>
<Package .../aries-protocol-test-suite/protocol_tests/connection>
  <Module test_manual.py>
    <Function test_connection_started_by_tested_agent>
    <Function test_connection_started_by_suite>

---- Available Tests ----
[
  {
    "name": "simple,0.1,*,simple",
    "description": "Show simple messages being passed to and from the test subject."
  },
  {
    "name": "connections,1.0,inviter,can-start",
    "description": "Test a connection as started by the agent under test."
  },
  {
    "name": "connections,1.0,invitee,can-receive",
    "description": "Test a connection as started by the suite."
  }
]

==== no tests ran in 0.04 seconds ====
```