### PR TITLE
Protocols as generators

### DIFF
--- a/protocol_tests/connection/__init__.py
+++ b/protocol_tests/connection/__init__.py
@@ -234,3 +234,7 @@ class Response(Message):
             crypto.verify_signed_message_field(self['connection~sig'])
         assert signer == expected_signer, 'Unexpected signer'
         del self['connection~sig']
+
+    def get_connection_info(self):
+        """Get connection information out of Request Message."""
+        return DIDDoc(self['connection']['DIDDoc']).get_connection_info()

--- a/protocol_tests/connection/test_manual.py
+++ b/protocol_tests/connection/test_manual.py
@@ -5,23 +5,24 @@ import pytest
 from aries_staticagent import crypto
 from reporting import meta
 from . import Invite, Request, Response
+from .. import interrupt, last, event_message_map, run
 
+# Inviter:
 
-@pytest.mark.asyncio
-@meta(protocol='connections', version='1.0', role='inviter', name='can-start')
-async def test_connection_started_by_tested_agent(config, temporary_channel):
-    """Test a connection as started by the agent under test."""
+async def _inviter(config, temporary_channel):
+    """Inviter protocol generator."""
     invite = Invite.parse_invite(
         input('Input generated connection invite: ')
     )
 
-    print("\nReceived Invite:\n", invite.pretty_print())
+    yield 'invite', invite
 
     # Create my information for connection
     invite_key, invite_endpoint = invite.get_connection_info()
     with temporary_channel(invite_key, invite_endpoint) as conn:
 
-        # Send Connection Request to inviter
+        yield 'before_request', conn
+
         request = Request.make(
             'test-connection-started-by-tested-agent',
             conn.did,
@@ -29,55 +30,107 @@ async def test_connection_started_by_tested_agent(config, temporary_channel):
             config['endpoint']
         )
 
-        print("\nSending Request:\n", request.pretty_print())
-        print("Awaiting response from tested agent...")
+        yield 'request', conn, request
+
         response = Response(await conn.send_and_await_reply_async(
             request,
             condition=lambda msg: msg.type == Response.TYPE,
             timeout=30
         ))
 
+        yield 'response', conn, response
+
         response.validate_pre_sig_verify()
-        print(
-            "\nReceived Response (pre signature verification):\n",
-            response.pretty_print()
-        )
         response.verify_sig(invite_key)
         response.validate_post_sig_verify()
 
-        assert response['~thread']['thid'] == request.id
+        yield 'response_verified', conn, response
 
-        print(
-            "\nReceived Response (post signature verification):\n",
-            response.pretty_print()
-        )
+        _did, conn.their_vk_b58, conn.endpoint = response.get_connection_info()
+        conn.their_vk = crypto.b58_to_bytes(conn.their_vk_b58)
 
-        # To send more messages, update conn's their_vk and endpoint
-        # to those disclosed in the response.
+        yield 'complete', conn
+
+
+@pytest.fixture
+async def inviter(config, temporary_channel):
+    """Inviter fixture."""
+    generator = _inviter(config, temporary_channel)
+    yield generator
+    await generator.aclose()
 
 
 @pytest.mark.asyncio
-@meta(protocol='connections', version='1.0', role='invitee', name='can-receive')
-async def test_connection_started_by_suite(config, temporary_channel):
-    """Test a connection as started by the suite."""
+@meta(protocol='connections', version='1.0', role='inviter', name='can-be-inviter')
+async def test_connection_started_by_tested_agent(inviter):
+    """Test a connection as started by the agent under test."""
+    await run(inviter)
 
+
+@pytest.mark.asyncio
+@meta(protocol='connections', version='1.0', role='inviter', name='response-pre-sig-verify-valid')
+async def test_response_valid_pre(inviter):
+    """Response before signature verification is valid."""
+    _conn, response = await last(interrupt(inviter, on='response'))
+    response.validate_pre_sig_verify()
+
+
+@pytest.mark.asyncio
+@meta(protocol='connections', version='1.0', role='inviter', name='response-post-sig-verify-valid')
+async def test_response_valid_post(inviter):
+    """Response after signature verification is valid."""
+    _conn, response = await last(interrupt(inviter, on='response_verified'))
+    response.validate_post_sig_verify()
+
+
+@pytest.mark.asyncio
+@meta(protocol='connections', version='1.0', role='inviter', name='response-thid-matches-request')
+async def test_response_thid_matches_request(inviter):
+    """Response's thread has thid matching id of request."""
+    message_map = await event_message_map(inviter)
+    request = message_map['request'][0]
+    response = message_map['response'][0]
+    assert '~thread' in response
+    assert 'thid' in response['~thread']
+    assert response['~thread']['thid'] == request.id
+
+
+@pytest.mark.asyncio
+@meta(protocol='connections', version='1.0', role='inviter', name='responds-to-ping')
+async def test_finish_with_trust_ping(inviter):
+    """Inviter responds to trust ping after connection protocol completion."""
+    conn = await last(interrupt(inviter, on='complete'))
+    await conn.send_and_await_reply_async(
+        {
+            '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping',
+            'response_requested': True
+        },
+        condition=lambda msg: msg.type == 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response',
+        timeout=5,
+    )
+
+
+# Invitee:
+
+async def _invitee(config, temporary_channel):
+    """Protocol generator for Invitee role."""
     with temporary_channel() as invite_conn:
         invite = Invite.make(
             'test-suite-connection-started-by-suite',
             invite_conn.my_vk_b58,
             config['endpoint']
         )
-        invite_url = invite.to_url()
+        yield 'invite', invite_conn, invite
 
+        invite_url = invite.to_url()
         print("\n\nInvitation encoded as URL: ", invite_url)
 
-        print("Awaiting request from tested agent...")
         request = Request(await invite_conn.await_message(
             condition=lambda msg: msg.type == Request.TYPE,
             timeout=30
         ))
         request.validate()
-        print("\nReceived request:\n", request.pretty_print())
+        yield 'request', invite_conn, request
 
     # Drop invite connection by exiting "with" context (no longer listening for
     # messages with key matching invitation key).
@@ -87,23 +140,31 @@ async def test_connection_started_by_suite(config, temporary_channel):
 
     # Set up connection for relationship.
     with temporary_channel(their_vk, endpoint) as conn:
-
         response = Response.make(
             request.id,
             conn.did,
             conn.my_vk_b58,
             config['endpoint']
         )
-
-        print(
-            "\nSending Response (pre signature packing):\n",
-            response.pretty_print()
-        )
+        yield 'response', conn, response
 
         response.sign(signer=conn.my_vk_b58, secret=conn.my_sk)
-        print(
-            "\nSending Response (post signature packing):\n",
-            response.pretty_print()
-        )
+        yield 'signed_response', conn, response
 
         await conn.send_async(response)
+        yield 'complete', conn
+
+
+@pytest.fixture
+async def invitee(config, temporary_channel):
+    """Invitee fixture."""
+    generator = _invitee(config, temporary_channel)
+    yield generator
+    await generator.aclose()
+
+
+@pytest.mark.asyncio
+@meta(protocol='connections', version='1.0', role='invitee', name='can-be-invitee')
+async def test_connection_started_by_suite(invitee):
+    """Test a connection as started by the suite."""
+    await run(invitee)


### PR DESCRIPTION
This PR introduces a pattern of programming protocols as async python generators, including some helper functions to run those protocols and retrieve relevant information yielded by the generator.

I feel this is a fairly succinct way of creating flexible "protocols" that can be interrupted and resumed or only run to a certain point while keeping the method that implements the protocol clean and readable. That being said, I'm open to thoughts and feedback on the approach.

Taking the `inviter` role of the connection protocol, we get the following "protocol generator":
```python
async def _inviter(config, temporary_channel):
    """Inviter protocol generator."""
    invite = Invite.parse_invite(
        input('Input generated connection invite: ')
    )

    yield 'invite', invite

    # Create my information for connection
    invite_key, invite_endpoint = invite.get_connection_info()
    with temporary_channel(invite_key, invite_endpoint) as conn:

        yield 'before_request', conn

        request = Request.make(
            'test-connection-started-by-tested-agent',
            conn.did,
            conn.my_vk_b58,
            config['endpoint']
        )

        yield 'request', conn, request

        response = Response(await conn.send_and_await_reply_async(
            request,
            condition=lambda msg: msg.type == Response.TYPE,
            timeout=30
        ))

        yield 'response', conn, response

        response.validate_pre_sig_verify()
        response.verify_sig(invite_key)
        response.validate_post_sig_verify()

        yield 'response_verified', conn, response

        _did, conn.their_vk_b58, conn.endpoint = response.get_connection_info()
        conn.their_vk = crypto.b58_to_bytes(conn.their_vk_b58)

        yield 'complete', conn
```
Each yield represents a point at which the protocol can be stopped or values collected.

To simply run the protocol to completion:
```python
inviter = _inviter(config, temporary) # Create the generator; this will normally be a fixture
await run(inviter)
```

To run the protocol but stop it at a certain point:
```python
await run(interrupt(inviter, on='response_verified'))
```
Or to return the yielded values at that point:
```python
conn, response = await last(interrupt(inviter, on='response_verified'))
```
To resume the protocol:
```python
inviter = _inviter(config, temporary)
conn, request = await last(interrupt(inviter, on='request'))
# Do something else, maybe modify request
await run(inviter) # Resume the protocol
```
To collect all messages as a list:
```python
messages = await collect_messages(inviter)
```
To collect all messages as a list to a point in the protocol:
```python
messages_through_response = await collect_messages(interrupt(inviter, on='response'))
```
To get a map of messages emitted where the keys of the map are the "events":
```python
message_map = await event_message_map(inviter)
```
(which can also be interrupted, yielding a map with all messages up to a point)

And so on.

Again, I'm open to thoughts and feedback. I think this could be a useful structure but certainly wouldn't be a requirement for all protocol tests.