### PR TITLE
Discover features backchannel connection lookup

### DIFF
--- a/protocol_tests/discover_features/backchannel.py
+++ b/protocol_tests/discover_features/backchannel.py
@@ -2,12 +2,14 @@
 
 from abc import ABC
 
-from aries_staticagent import Message
+from aries_staticagent import StaticConnection
+
 
 class DiscoverFeaturesBackchannel(ABC):
     """Backchannel methods for discover-features protocol."""
 
-    async def discover_features_v1_0_requester_start(self, verkey, query=".*", comment=None):
+    async def discover_features_v1_0_requester_start(
+            self, connection: StaticConnection, query=".*", comment=None
+    ):
         """Start discover-features protocol from the requester role."""
         raise NotImplementedError()
-

--- a/protocol_tests/discover_features/test_discover_features.py
+++ b/protocol_tests/discover_features/test_discover_features.py
@@ -22,7 +22,9 @@ async def requester(backchannel, connection, query, comment):
     connection.route_module(handler)
     count = handler.query_message_count
     # Now tell the agent under test to send a query message
-    resp = await backchannel.discover_features_v1_0_requester_start(connection.verkey_b58, query, comment)
+    await backchannel.discover_features_v1_0_requester_start(
+        connection, query, comment
+    )
     # Make sure an additional message was received
     assert handler.query_message_count == count + 1
 


### PR DESCRIPTION
Pass connection object to backchannel for specifying connection to which
to send the query. This makes this backchannel API more consistent with
others.

Signed-off-by: Daniel Bluhm <daniel.bluhm@sovrin.org>