### PR TITLE
Properly send and receive the ~thread decorator. 

### DIFF
--- a/protocol_tests/issue_credential/test_issue_credential.py
+++ b/protocol_tests/issue_credential/test_issue_credential.py
@@ -21,7 +21,7 @@ from . import Handler
 @meta(protocol='issue-credential', version='1.0', role='issuer', name='issuer-initiated')
 async def test_issuer_v1_0_issuer_initiated(backchannel, connection, cred_def1, handler):
     """The agent under test initiates the issuance flow with an offer."""
-    handler.reset_events()
+    handler.reset()
     connection.route_module(handler)
     # Send a credential offer to the test-suite.  The remainder of the flow is automatic since the test-suite automatically
     # accepts the offer and stores the credential.
@@ -45,7 +45,7 @@ async def cred_def1(backchannel, config):
 @meta(protocol='issue-credential', version='1.0', role='holder', name='issuer-initiated')
 async def test_holder_v1_0_issuer_initiated(backchannel, connection, cred_def2, handler):
     """The test suite initiates the issuance flow wth an offer."""
-    handler.reset_events()
+    handler.reset()
     connection.route_module(handler)
     # Send a credential offer to the agent under test
     id = await handler.send_offer_credential(connection, cred_def2, {

--- a/protocol_tests/present_proof/test_present_proof.py
+++ b/protocol_tests/present_proof/test_present_proof.py
@@ -21,7 +21,7 @@ from . import Handler
 @meta(protocol='present-proof', version='1.0', role='prover', name='verifier-initiated')
 async def test_present_proof_v1_0_prover_verifier_initiated(backchannel, connection, cred_def, handler):
     """The test suite begins the present-proof flow by sending a request-presentation message to the agent-under-test."""
-    handler.reset_events()
+    handler.reset()
     # The test suite sends a proof request to the agent-under-test
     proof_request = {
         "name": "aries-test-proof-request1",
@@ -68,7 +68,7 @@ async def cred_def(handler, connection, backchannel):
 @meta(protocol='present-proof', version='1.0', role='verifier', name='prover-initiated')
 async def test_present_proof_v1_0_issuer_initiated(backchannel, connection, handler):
     """The agent-under-test begins the present-proof flow by sending a request-presentation message to the agent-under-test."""
-    handler.reset_events()
+    handler.reset()
     # Initialize the test suite with a credential
     (schema_id, cred_def_id) = await handler.setup_prover("VerifierSchema", "1.0", {"str1": "str1val", "int1": "10"})
     # Tell the agent-under-test to send a proof request


### PR DESCRIPTION
I added a BaseModule class to protocol_tests/__init__.py which is extended by the discover_features, issue_credential, and present_proof protocols.  The BaseModule contains code to properly send and receive the ~thread decorator.

Prior to this fix, the ~thread decorator was manually handled in each case.  Sometimes it was correct but often it was not sending the sender_order or received_orders fields at all.  It also was not checking for correctness for incoming messages.  These changes address this for these protocols.

Signed-off-by: Keith Smith <bksmith@us.ibm.com>