### PR TITLE
Fix TAA timestamp problem which was causing a pool timeout on Sovrin …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Aries Protocol Test Suite Configuration files
-config.toml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/apts/src/config.toml
+++ b/apts/src/config.toml
@@ -1,0 +1,38 @@
+## Aries Protocol Test Suite Configuration ##
+
+[config]
+# HTTP Server options
+host = "apts"
+port = 4000
+
+# Endpoint reported to other agents
+endpoint = "http://apts:4000"
+backchannel = 'aut.AUTBackchannel'
+
+# Use the indy provider
+provider = 'indy_provider.IndyProvider'
+
+# Set the ledger used by APTS.
+# The following config refers to the ledger container in aries-protocol-test-suite/docker-compose.yml.
+ledger_name = 'local'
+ledger_url = 'http://ledger:8000/sandbox/pool_transactions_genesis'
+ledger_apts_seed = '000000000000000000000000STEWARD1'
+# The following config refers to the Sovrin staging ledger.
+# ledger_name = 'sovrin.staging'
+# ledger_url = 'https://raw.githubusercontent.com/sovrin-foundation/sovrin/master/sovrin/pool_transactions_sandbox_genesis'
+# ledger_apts_seed = '0000000000000000000000000000APTS'
+
+# List of regular expressions used to select tests.
+# If a test name matches at least one regex in this list, it will be selected for execution.
+tests = [
+   "connections.*",
+   "issue-credential.*",
+   "present-proof.*",
+]
+
+[config.subject]
+# Name and version reported in interop profile
+name = "AGENT UNDER TEST"
+version = "1.0.0"
+# Endpoint used for backchannel
+endpoint="http://apts:4001"

--- a/indy_provider.py
+++ b/indy_provider.py
@@ -1,12 +1,6 @@
-import json
-import aiohttp
-import base64
-import time
-import sys
-import hashlib
-import random
-import string
+import json, aiohttp, base64, sys, hashlib, random, string
 
+from datetime import datetime, date
 from protocol_tests.provider import Provider
 from protocol_tests.issue_credential.provider import IssueCredentialProvider
 from indy import anoncreds, wallet, ledger, pool, crypto, did, pairwise, non_secrets, ledger, wallet, blob_storage
@@ -28,10 +22,10 @@ class IndyProvider(Provider, IssueCredentialProvider):
             raise Exception(
                 "The Indy provider requires a 'ledger_url' value in config.toml")
         self.ledger_url = config['ledger_url']
-        if not 'seed' in config:
+        if not 'ledger_apts_seed' in config:
             raise Exception(
-                "The Indy provider requires a 'seed' value in config.toml")
-        seed = config['seed']
+                "The Indy provider requires a 'ledger_apts_seed' value in config.toml")
+        seed = config['ledger_apts_seed']
         id = config.get('name', 'test')
         key = config.get('pass', 'testpw')
         self.cfg = json.dumps({'id': id})
@@ -295,7 +289,7 @@ class IndyProvider(Provider, IssueCredentialProvider):
         taa = (json.loads(response))["result"]["data"]
         if not taa:
             return req
-        curTime = int(round(time.time() * 1000))
+        curTime = int(datetime.combine(date.today(), datetime.min.time()).timestamp())
         req = await ledger.append_txn_author_agreement_acceptance_to_request(req,taa["text"],taa["version"],taa["digest"],"wallet",curTime)
         return req
 


### PR DESCRIPTION
Fix TAA timestamp problem which was causing a pool timeout on Sovrin staging.   The indy-node code requires a timestamp in secs.  I stole this taa timestamp computation from ACA-py.

I'm also checking in the sample apts/src/config.toml; it was not checked in before because it was listed in the .gitignore file, so I fixed that.

Signed-off-by: Keith Smith <bksmith@us.ibm.com>