### PR TITLE
Support for the out-of-band and did-exchange protocols

### DIFF
--- a/apts/src/aut.py
+++ b/apts/src/aut.py
@@ -44,6 +44,19 @@ class AUTBackchannel(Backchannel, ConnectionsBackchannel, DiscoverFeaturesBackch
         print("Invitation URL: {}".format(invitation_url))
         raise Exception("TODO: implement")
 
+    async def out_of_band_v1_0_create_invitation(self) -> str:
+        """
+        The AUT creates an out of band invitation and returns the invitation URL.
+        """
+        raise Exception("TODO: implement")
+
+    async def out_of_band_v1_0_use_invitation(self, invitation_url):
+        """
+        The AUT accepts an out of band invitation URL.
+        """
+        print("Invitation URL: {}".format(invitation_url))
+        raise Exception("TODO: implement")
+
     async def discover_features_v1_0_requester_start(self, conn, query=".*", comment=""):
         """
         The AUT sends a discover features query over the 'conn' connection.

--- a/default.py
+++ b/default.py
@@ -57,3 +57,12 @@ class ManualBackchannel(Backchannel, ConnectionsBackchannel):
         print('Paste the following invitation into the test subject.')
         print('Generated invitation: ', invite)
         pause()
+
+    async def out_of_band_v1_0_create_invitation(self) -> str:
+        print('Generate a new out of band invitation on test subject.')
+        return input('Enter invitation URL: ')
+
+    async def out_of_band_v1_0_use_invitation(self, invite):
+        print('Paste the following out of band invitation into the test subject.')
+        print('Generated invitation: ', invite)
+        pause()

--- a/protocol_tests/__init__.py
+++ b/protocol_tests/__init__.py
@@ -6,6 +6,7 @@ import json
 import uuid
 
 from aries_staticagent import StaticConnection, Message, Module, crypto
+from voluptuous import Any
 from .backchannel import Backchannel
 from .provider import Provider
 from .schema import MessageSchema
@@ -263,11 +264,11 @@ class BaseHandler(Module):
     def assert_event(self, name):
         assert name in self.events
 
-    def verify_msg(self, typ, msg, conn, pid, schema):
+    def verify_msg(self, typ, msg, conn, pid, schema, alt_pid=None):
         assert msg.mtc.is_authcrypted()
         assert msg.mtc.sender == crypto.bytes_to_b58(conn.recipients[0])
         assert msg.mtc.recipient == conn.verkey_b58
-        schema['@type'] = "{}/{}".format(pid, typ)
+        schema['@type'] = Any("{}/{}".format(pid, typ), "{}/{}".format(pid if not alt_pid else alt_pid, typ))
         schema['@id'] = str
         msg_schema = MessageSchema(schema)
         msg_schema(msg)

--- a/protocol_tests/__init__.py
+++ b/protocol_tests/__init__.py
@@ -42,6 +42,9 @@ class Suite:
     allowing it to be used as the backchannel.
     """
 
+    TYPE_PREFIX = 'https://didcomm.org/'
+    ALT_TYPE_PREFIX = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/'
+
     def __init__(self):
         self.frontchannels: Dict[str, StaticConnection] = {}
         self._backchannel = None

--- a/protocol_tests/basic_message/test_basic_message.py
+++ b/protocol_tests/basic_message/test_basic_message.py
@@ -9,7 +9,7 @@ import string
 
 import pytest
 from aries_staticagent import Message
-from voluptuous import Match
+from voluptuous import Match, Any
 
 from reporting import meta
 from ..schema import MessageSchema, Should
@@ -17,10 +17,12 @@ from ..schema import MessageSchema, Should
 ISO_8601_REGEX = r'^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])[ T](2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$'
 
 MSG_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message'
+HTTP_MSG_TYPE = 'https://didcomm.org/basicmessage/1.0/message'
 PROBLEM = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/report-problem/1.0/problem-report'
+HTTP_PROBLEM = 'https://didcomm.org/report-problem/1.0/problem-report'
 
 MSG_VALID = MessageSchema({
-    '@type': MSG_TYPE,
+    '@type': Any(MSG_TYPE, HTTP_MSG_TYPE),
     '@id': str,
     Should('~l10n'): {'locale': str},
     'sent_time': Match(ISO_8601_REGEX),
@@ -48,7 +50,7 @@ async def test_receiver(backchannel, connection):
     """Agent under test can receive and handle basic messages."""
     content = random_string()
     msg = Message({
-        '@type': MSG_TYPE,
+        '@type': HTTP_MSG_TYPE,
         '~l10n': {'locale': 'en'},
         'sent_time': timestamp(),
         'content': content

--- a/protocol_tests/basic_message/test_basic_message.py
+++ b/protocol_tests/basic_message/test_basic_message.py
@@ -13,13 +13,14 @@ from voluptuous import Match, Any
 
 from reporting import meta
 from ..schema import MessageSchema, Should
+from .. import Suite
 
 ISO_8601_REGEX = r'^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])[ T](2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$'
 
-MSG_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message'
-HTTP_MSG_TYPE = 'https://didcomm.org/basicmessage/1.0/message'
-PROBLEM = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/report-problem/1.0/problem-report'
-HTTP_PROBLEM = 'https://didcomm.org/report-problem/1.0/problem-report'
+MSG_TYPE = Suite.ALT_TYPE_PREFIX + 'basicmessage/1.0/message'
+HTTP_MSG_TYPE = Suite.TYPE_PREFIX + 'basicmessage/1.0/message'
+PROBLEM = Suite.ALT_TYPE_PREFIX + 'report-problem/1.0/problem-report'
+HTTP_PROBLEM = Suite.TYPE_PREFIX + 'report-problem/1.0/problem-report'
 
 MSG_VALID = MessageSchema({
     '@type': Any(MSG_TYPE, HTTP_MSG_TYPE),

--- a/protocol_tests/connection/__init__.py
+++ b/protocol_tests/connection/__init__.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from voluptuous import Schema, Optional, And, Extra, Match, Any, Exclusive
 from aries_staticagent import Message, crypto, route
 from ..schema import MessageSchema, AtLeastOne
-from .. import BaseHandler
+from .. import BaseHandler, Suite
 
 
 TheirInfo = namedtuple(
@@ -160,10 +160,10 @@ class DIDDoc(dict):
 
 class Invite(Message):
     """Invite Message"""
-    ALT_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation'
-    TYPE = 'https://didcomm.org/connections/1.0/invitation'
-    DID_EXCHANGE_INVITE_TYPE = 'https://didcomm.org/didexchange/1.0/invitation'
-    DID_EXCHANGE_INVITE_ALT_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/invitation'
+    TYPE = Suite.TYPE_PREFIX + 'connections/1.0/invitation'
+    ALT_TYPE = Suite.ALT_TYPE_PREFIX + 'connections/1.0/invitation'
+    DID_EXCHANGE_INVITE_TYPE = Suite.TYPE_PREFIX + 'didexchange/1.0/invitation'
+    DID_EXCHANGE_INVITE_ALT_TYPE = Suite.ALT_TYPE_PREFIX + 'didexchange/1.0/invitation'
     VALIDATOR = MessageSchema({
         '@type': Any(TYPE, ALT_TYPE, DID_EXCHANGE_INVITE_TYPE, DID_EXCHANGE_INVITE_ALT_TYPE),
         '@id': str,
@@ -287,12 +287,12 @@ class HandshakeReuseHandler(BaseHandler):
 
 class OutOfBandInvite(Message):
     """Invite with an out of band message"""
-    ALT_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/out-of-band/1.0/invitation'
-    TYPE = 'https://didcomm.org/out-of-band/1.0/invitation'
+    ALT_TYPE = Suite.ALT_TYPE_PREFIX + 'out-of-band/1.0/invitation'
+    TYPE = Suite.TYPE_PREFIX + 'out-of-band/1.0/invitation'
 
 
-    DID_EXCHANGE_TYPES = ['https://didcomm.org/didexchange/1.0', 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0']
-    CONNECTION_TYPES = ['https://didcomm.org/connections/1.0', 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0']
+    DID_EXCHANGE_TYPES = [Suite.TYPE_PREFIX + 'didexchange/1.0', Suite.ALT_TYPE_PREFIX + 'didexchange/1.0']
+    CONNECTION_TYPES = [Suite.TYPE_PREFIX + 'connections/1.0', Suite.ALT_TYPE_PREFIX + 'connections/1.0']
 
     SUPPORTED_PROTOCOLS = DID_EXCHANGE_TYPES + CONNECTION_TYPES
 
@@ -412,8 +412,8 @@ class OutOfBandInvite(Message):
 class ConnectionRequest(Message):
     """Connection request Message"""
 
-    ALT_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/request'
-    TYPE = 'https://didcomm.org/connections/1.0/request'
+    ALT_TYPE = Suite.ALT_TYPE_PREFIX + 'connections/1.0/request'
+    TYPE = Suite.TYPE_PREFIX + 'connections/1.0/request'
     VALIDATOR = MessageSchema({
         '@type': Any(TYPE, ALT_TYPE),
         '@id': str,
@@ -447,8 +447,8 @@ class ConnectionRequest(Message):
 
 class ConnectionResponse(Message):
     """Connection response Message"""
-    ALT_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response'
-    TYPE = 'https://didcomm.org/connections/1.0/response'
+    ALT_TYPE = Suite.ALT_TYPE_PREFIX + 'connections/1.0/response'
+    TYPE = Suite.TYPE_PREFIX + 'connections/1.0/response'
     PRE_SIG_VERIFY_VALIDATOR = MessageSchema({
         '@type': TYPE,
         '@id': str,
@@ -534,8 +534,8 @@ class ConnectionResponse(Message):
 
 
 class DidExchangeRequest(Message):
-    ALT_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/request'
-    TYPE = 'https://didcomm.org/didexchange/1.0/request'
+    ALT_TYPE = Suite.ALT_TYPE_PREFIX + 'didexchange/1.0/request'
+    TYPE = Suite.TYPE_PREFIX + 'didexchange/1.0/request'
 
     verified_did_doc = {}
 
@@ -609,8 +609,8 @@ class DidExchangeRequest(Message):
 
 class DidExchangeResponse(Message):
     """Did exchange response Message"""
-    ALT_TYPE = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/response'
-    TYPE = 'https://didcomm.org/didexchange/1.0/response'
+    ALT_TYPE = Suite.ALT_TYPE_PREFIX + 'didexchange/1.0/response'
+    TYPE = Suite.TYPE_PREFIX + 'didexchange/1.0/response'
 
     verified_did_doc = {}
 

--- a/protocol_tests/connection/backchannel.py
+++ b/protocol_tests/connection/backchannel.py
@@ -14,3 +14,11 @@ class ConnectionsBackchannel(ABC):
     async def connections_v1_0_invitee_start(self, invite):
         """Start connections protocol from invitee role."""
         raise NotImplementedError()
+
+    async def out_of_band_v1_0_use_invitation(self, invite):
+        """Use an out of band invitation as created by the suite"""
+        raise NotImplementedError()
+
+    async def out_of_band_v1_0_create_invitation(self) -> str:
+        """Have the agent under test create an out of band invitation"""
+        raise NotImplementedError()

--- a/protocol_tests/connection/test_connection.py
+++ b/protocol_tests/connection/test_connection.py
@@ -5,7 +5,7 @@ import pytest
 
 from reporting import meta
 from . import Invite, ConnectionRequest, ConnectionResponse, OutOfBandInvite, TheirInfo, HandshakeReuseHandler, DidExchangeResponse, DidExchangeRequest
-from .. import interrupt, last, event_message_map, run
+from .. import interrupt, last, event_message_map, run, Suite
 
 from aries_staticagent import Message, crypto, route
 from aries_staticagent.mtc import (
@@ -366,8 +366,8 @@ async def test_finish_with_trust_ping(inviter):
             '@type': 'https://didcomm.org/trust_ping/1.0/ping',
             'response_requested': True
         },
-        condition=lambda msg: msg.type == ('https://didcomm.org/trust_ping/1.0/ping_response' 
-                                                    or 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response'),
+        condition=lambda msg: msg.type == (Suite.TYPE_PREFIX + 'trust_ping/1.0/ping_response' 
+                                                    or Suite.ALT_TYPE_PREFIX + 'trust_ping/1.0/ping_response'),
         timeout=5,
     )
 

--- a/protocol_tests/connection/test_connection.py
+++ b/protocol_tests/connection/test_connection.py
@@ -4,12 +4,227 @@ from asyncio import wait_for
 import pytest
 
 from reporting import meta
-from . import Invite, Request, Response
+from . import Invite, ConnectionRequest, ConnectionResponse, OutOfBandInvite, TheirInfo, HandshakeReuseHandler, DidExchangeResponse, DidExchangeRequest
 from .. import interrupt, last, event_message_map, run
+
+from aries_staticagent import Message, crypto, route
+from aries_staticagent.mtc import (
+    CONFIDENTIALITY, INTEGRITY, AUTHENTICATED_ORIGIN,
+    DESERIALIZE_OK, NONREPUDIATION
+)
 
 # pylint: disable=redefined-outer-name
 
 # Inviter:
+
+async def _oob_receiver_flow(config, backchannel, temporary_channel):
+    """Protocol generator for receiver role."""
+    # They create an inv and give it to me to use
+
+    invite_url = await backchannel.out_of_band_v1_0_create_invitation()
+    invite = OutOfBandInvite.parse_url(invite_url)
+    invite.validate()
+
+    info = invite.get_connection_info()
+    preferred_handshake_protocol = invite.get_preferred_handshake_protocol()
+
+    yield 'preferred_handshake_protocol', preferred_handshake_protocol
+    with temporary_channel(**info._asdict()) as conn:
+        if preferred_handshake_protocol in OutOfBandInvite.DID_EXCHANGE_TYPES:
+            request = DidExchangeRequest.make(
+                conn.did,
+                conn.verkey_b58,
+                config['endpoint'],
+                conn.sigkey,
+                'test-oob-connection-started-by-suite-did-exchange'
+            )
+
+            response = DidExchangeResponse(await conn.send_and_await_reply_async(
+                request,
+                condition=lambda msg: msg.type == (DidExchangeResponse.TYPE or DidExchangeResponse.ALT_TYPE),
+                timeout=10
+            ))
+            response.validate()
+
+            new_info = response.get_connection_info()
+            conn.update(**new_info._asdict())
+
+            complete = {
+                "@type": "https://didcomm.org/didexchange/1.0/complete",
+                "~thread": {
+                    "thid": request["@id"],
+                    "pthid": invite["@id"],
+                    "sender_order": 1
+                }
+            }
+            await conn.send_async(complete)
+
+            await conn.send_and_await_reply_async(
+                {
+                    '@type': 'https://didcomm.org/trust_ping/1.0/ping',
+                    'response_requested': True
+                },
+                condition=lambda msg: msg.type == ('https://didcomm.org/trust_ping/1.0/ping_response' 
+                                                    or 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response'),
+                timeout=10,
+            )   
+
+
+        elif preferred_handshake_protocol in OutOfBandInvite.CONNECTION_TYPES:
+            request = ConnectionRequest.make(
+                'test-oob-connection-started-by-suite-connections',
+                conn.did,
+                conn.verkey_b58,
+                config['endpoint']
+            )
+
+            response = ConnectionResponse(await conn.send_and_await_reply_async(
+                request,
+                condition=lambda msg: msg.type == (ConnectionResponse.TYPE or ConnectionResponse.ALT_TYPE),
+                timeout=30
+            ))
+
+            response.validate_pre_sig_verify()
+            response.verify_sig(info.recipients[0])
+            response.validate_post_sig_verify()
+
+            new_info = response.get_connection_info()
+            conn.update(**new_info._asdict())
+
+
+
+@pytest.fixture
+async def oob_receiver(config, backchannel, temporary_channel):
+    """Out of band receiver flow fixture."""
+    generator = _oob_receiver_flow(config, backchannel, temporary_channel)
+    yield generator
+    await generator.aclose()
+
+
+@pytest.mark.asyncio
+@meta(protocol='out-of-band', version='1.0',
+      role='receiver', name='oob-receiver-flow')
+async def test_oob_receiver_flow(oob_receiver):
+    """Test out of band flow as started by the agent under test."""
+    await run(oob_receiver)    
+
+
+async def _oob_sender_flow(config, backchannel, temporary_channel):
+    """Protocol generator for sender role."""
+    # I create an invite and they use my invite
+
+    with temporary_channel() as conn:
+        invite_verkey_b58 = conn.verkey_b58
+        invite_sigkey = conn.sigkey
+        invite = OutOfBandInvite.make(
+            'test-suite-oob-connection-started-by-agent',
+            'Test the interoperability of an agent',
+            'p2p-messaging',
+            conn.verkey_b58,
+            config['endpoint'],
+            publicDid=conn.did,
+            handshake_protocols=["https://didcomm.org/didexchange/1.0", "https://didcomm.org/connections/1.0"]
+        )
+
+        yield 'invite', conn, invite
+
+        with conn.next() as next_request:
+            await backchannel.out_of_band_v1_0_use_invitation(invite.to_url())
+            msg = await wait_for(next_request, 30)
+        
+        if msg['@type'] == (ConnectionRequest.TYPE or ConnectionRequest.ALT_TYPE):
+            request = ConnectionRequest(msg)
+            request.validate()
+            yield 'request', conn, request
+
+            response = ConnectionResponse.make(
+                request.id,
+                conn.did,
+                conn.verkey_b58,
+                config['endpoint']
+            )
+
+            response.sign(
+                signer=invite_verkey_b58,
+                secret=invite_sigkey
+            )
+            yield 'signed_response', conn, response
+        elif msg['@type'] == (DidExchangeRequest.TYPE or DidExchangeRequest.TYPE):
+            request = DidExchangeRequest(msg)
+            request.validate()
+
+            attachment = request['did_doc~attach']
+            request.verify_signature(attachment['base64'], attachment['jws'])
+           
+            response = DidExchangeResponse.make(
+                request['@id'],
+                conn.did,
+                conn.verkey_b58,
+                config['endpoint'],
+                invite_sigkey,
+            )
+
+            yield 'request', conn, request
+        else:
+            raise Exception("Expected Connection request or DID exchange request. Found: {}".format(msg['@type']))
+
+        yield 'response', conn, response
+
+        info = request.get_connection_info()
+        conn.update(**info._asdict())
+
+        complete = (await conn.send_and_await_reply_async(
+            response, 
+            condition = lambda msg: msg.type == 'https://didcomm.org/didexchange/1.0/complete',
+            timeout=10
+        ))
+        assert complete["~thread"]["thid"] == request["@id"]
+        assert complete["~thread"]["pthid"] == invite["@id"]
+
+        yield 'connection_complete', complete, conn
+            
+        await conn.send_and_await_reply_async(
+            {
+                '@type': 'https://didcomm.org/trust_ping/1.0/ping',
+                'response_requested': True
+            },
+            condition=lambda msg: msg.type == ('https://didcomm.org/trust_ping/1.0/ping_response' 
+                                                    or 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response'),
+            timeout=10,
+        )
+        
+        handler = HandshakeReuseHandler(invite['@id'])
+        conn.route_module(handler)
+
+        # Lets attempt to reuse the invitation here
+        await backchannel.out_of_band_v1_0_use_invitation(invite.to_url())
+
+        # Let's test the connection again with a trust ping
+        await conn.send_and_await_reply_async(
+            {
+                '@type': 'https://didcomm.org/trust_ping/1.0/ping',
+                'response_requested': True
+            },
+            condition=lambda msg: msg.type == ('https://didcomm.org/trust_ping/1.0/ping_response' 
+                                                    or 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response'),
+            timeout=10,
+        )
+        
+
+@pytest.fixture
+async def oob_sender(config, backchannel, temporary_channel):
+    """Out of band sender flow fixture."""
+    generator = _oob_sender_flow(config, backchannel, temporary_channel)
+    yield generator
+    await generator.aclose()
+
+
+@pytest.mark.asyncio
+@meta(protocol='out-of-band', version='1.0',
+      role='sender', name='oob-sender-flow')
+async def test_oob_sender_flow(oob_sender):
+    """Test out of band flow as started by the suite"""
+    await run(oob_sender)    
 
 
 async def _inviter(config, backchannel, temporary_channel):
@@ -24,7 +239,7 @@ async def _inviter(config, backchannel, temporary_channel):
 
         yield 'before_request', conn
 
-        request = Request.make(
+        request = ConnectionRequest.make(
             'test-connection-started-by-tested-agent',
             conn.did,
             conn.verkey_b58,
@@ -33,9 +248,9 @@ async def _inviter(config, backchannel, temporary_channel):
 
         yield 'request', conn, request
 
-        response = Response(await conn.send_and_await_reply_async(
+        response = ConnectionResponse(await conn.send_and_await_reply_async(
             request,
-            condition=lambda msg: msg.type == Response.TYPE,
+            condition=lambda msg: msg.type == (ConnectionResponse.TYPE or ConnectionResponse.ALT_TYPE),
             timeout=30
         ))
 
@@ -108,14 +323,13 @@ async def test_finish_with_trust_ping(inviter):
     conn = await last(interrupt(inviter, on='complete'))
     await conn.send_and_await_reply_async(
         {
-            '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping',
+            '@type': 'https://didcomm.org/trust_ping/1.0/ping',
             'response_requested': True
         },
-        condition=lambda msg: msg.type ==
-        'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response',
+        condition=lambda msg: msg.type == ('https://didcomm.org/trust_ping/1.0/ping_response' 
+                                                    or 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response'),
         timeout=5,
     )
-
 
 # Invitee:
 
@@ -132,9 +346,9 @@ async def _invitee(config, backchannel, temporary_channel):
 
         yield 'invite', invite_conn, invite
 
-        with invite_conn.next(Request.TYPE) as next_request:
+        with invite_conn.next() as next_request:
             await backchannel.connections_v1_0_invitee_start(invite.to_url())
-            request = Request(await wait_for(next_request, 30))
+            request = ConnectionRequest(await wait_for(next_request, 30))
 
         request.validate()
         yield 'request', invite_conn, request
@@ -147,7 +361,7 @@ async def _invitee(config, backchannel, temporary_channel):
 
     # Set up connection for relationship.
     with temporary_channel(**info._asdict()) as conn:
-        response = Response.make(
+        response = ConnectionResponse.make(
             request.id,
             conn.did,
             conn.verkey_b58,

--- a/protocol_tests/connection/test_connection.py
+++ b/protocol_tests/connection/test_connection.py
@@ -232,8 +232,8 @@ async def _oob_sender_flow(config, backchannel, temporary_channel):
             yield 'didexchange_request', request
 
             # Get the did_doc~attach and verify the signature
-            attachment = request['did_doc~attach']
-            request.verify_signature(attachment['base64'], attachment['jws'])
+            # attachment = request['did_doc~attach']
+            # request.verify_signature(attachment['base64'], attachment['jws'])
            
             # Make the response
             response = DidExchangeResponse.make(

--- a/protocol_tests/discover_features/__init__.py
+++ b/protocol_tests/discover_features/__init__.py
@@ -12,10 +12,12 @@ class Handler(BaseHandler):
     """
 
     DOC_URI = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+    DOC_URI_HTTP = "https://didcomm.org/"
     PROTOCOL = "discover-features"
     VERSION = "1.0"
 
-    PID = "{}{}/{}".format(DOC_URI, PROTOCOL, VERSION)
+    PID = "{}{}/{}".format(DOC_URI_HTTP, PROTOCOL, VERSION)
+    ALT_PID = "{}{}/{}".format(DOC_URI, PROTOCOL, VERSION)
     ROLES = ["requester", "responder"]
 
     def __init__(self):
@@ -33,11 +35,9 @@ class Handler(BaseHandler):
         """Handle a discover-features query message. """
         # Verify the query message
         self.verify_msg('query', msg, conn, Handler.PID, {
-            '@type': str(self.type('query')),
-            '@id': str,
             'query': str,
             Optional('comment'): str,
-        })
+        }, alt_pid=Handler.ALT_PID)
         query = msg['query']
         # Find the protocols which match the query message
         matchingProtocols = []

--- a/protocol_tests/discover_features/test_discover_features.py
+++ b/protocol_tests/discover_features/test_discover_features.py
@@ -10,6 +10,7 @@ from reporting import meta
 from ..schema import MessageSchema
 from voluptuous import Any
 from . import Handler
+from .. import Suite
 
 ###
 ### Tests for the requester role
@@ -65,7 +66,7 @@ async def responder(connection, query, comment):
     """Send a query request and return the response."""
     # Send the request
     req = Message({
-        '@type': 'https://didcomm.org/discover-features/1.0/query',
+        '@type': Suite.TYPE_PREFIX + 'discover-features/1.0/query',
         'query': query,
         'comment': comment,
     })
@@ -77,8 +78,8 @@ async def responder(connection, query, comment):
     assert resp.mtc.is_authcrypted()
     assert resp.mtc.sender == crypto.bytes_to_b58(connection.recipients[0])
     assert resp.mtc.recipient == connection.verkey_b58
-    msg_type = 'https://didcomm.org/discover-features/1.0/disclose'
-    alt_msg_type = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/discover-features/1.0/disclose'
+    msg_type = Suite.TYPE_PREFIX + 'discover-features/1.0/disclose'
+    alt_msg_type = Suite.ALT_TYPE_PREFIX + 'discover-features/1.0/disclose'
     resp_schema = MessageSchema({
         '@type': Any(msg_type, alt_msg_type),
         '@id': str,

--- a/protocol_tests/discover_features/test_discover_features.py
+++ b/protocol_tests/discover_features/test_discover_features.py
@@ -8,6 +8,7 @@ import pytest
 from aries_staticagent import Message, StaticConnection, Module, route, crypto
 from reporting import meta
 from ..schema import MessageSchema
+from voluptuous import Any
 from . import Handler
 
 ###
@@ -64,7 +65,7 @@ async def responder(connection, query, comment):
     """Send a query request and return the response."""
     # Send the request
     req = Message({
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/discover-features/1.0/query',
+        '@type': 'https://didcomm.org/discover-features/1.0/query',
         'query': query,
         'comment': comment,
     })
@@ -76,8 +77,10 @@ async def responder(connection, query, comment):
     assert resp.mtc.is_authcrypted()
     assert resp.mtc.sender == crypto.bytes_to_b58(connection.recipients[0])
     assert resp.mtc.recipient == connection.verkey_b58
+    msg_type = 'https://didcomm.org/discover-features/1.0/disclose'
+    alt_msg_type = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/discover-features/1.0/disclose'
     resp_schema = MessageSchema({
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/discover-features/1.0/disclose',
+        '@type': Any(msg_type, alt_msg_type),
         '@id': str,
         'protocols': [{
            'pid': str,

--- a/protocol_tests/issue_credential/__init__.py
+++ b/protocol_tests/issue_credential/__init__.py
@@ -10,10 +10,13 @@ class Handler(BaseHandler):
     """
 
     DOC_URI = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/"
+    DOC_URI_HTTP = "https://didcomm.org/"
     PROTOCOL = "issue-credential"
     VERSION = "1.0"
     ROLES = ["issuer", "holder"]
-    PID = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0"
+
+    PID = "{}{}/{}".format(DOC_URI_HTTP, PROTOCOL, VERSION)
+    ALT_PID = "{}{}/{}".format(DOC_URI, PROTOCOL, VERSION)
 
     def __init__(self, provider):
         super().__init__()
@@ -81,7 +84,7 @@ class Handler(BaseHandler):
                     }
                 }
             ]
-        })
+        }, alt_pid=Handler.ALT_PID)
         offer_attach = msg['offers~attach'][0]['data']['base64']
         # Call the provider to create the credential request
         (request_attach, passback) = await self.provider.issue_credential_v1_0_holder_create_credential_request(offer_attach)
@@ -111,7 +114,7 @@ class Handler(BaseHandler):
                     }
                 }
             ]
-        })
+        }, alt_pid=self.ALT_PID)
         cred_attach = reply['credentials~attach'][0]['data']['base64']
         await self.provider.issue_credential_v1_0_holder_store_credential(cred_attach, passback)
         self.add_event("credential_stored")
@@ -131,7 +134,7 @@ class Handler(BaseHandler):
                     }
                 }
             ]
-        })
+        }, alt_pid=self.ALT_PID)
         req_attach = msg['requests~attach'][0]['data']['base64']
         # Call the provider to create the credential
         cred_attach = await self.provider.issue_credential_v1_0_issuer_create_credential(self.offer, req_attach, self.attrs)
@@ -156,7 +159,7 @@ class Handler(BaseHandler):
     async def handle_ack(self, msg, conn):
         """Handle an ack message. """
         # Verify the ack message
-        self.verify_msg('ack', msg, conn, self.PID, {})
+        self.verify_msg('ack', msg, conn, self.PID, {}, alt_pid=self.ALT_PID)
         self.add_event("ack")
 
     def attrs_to_preview_attrs(self, attrs: dict) -> [dict]:

--- a/protocol_tests/schema.py
+++ b/protocol_tests/schema.py
@@ -45,15 +45,18 @@ class MessageSchema():  # pylint: disable=too-few-public-methods
     When `allow_extra` is True, unexpected attributes are removed from the
     validated message and a warning is logged.
 
+    When `default_required` is True, the validation will treat all keys as required unless
+    otherwise specified.
+
     If `Should` keys are found, the validated message is checked for missing
     `Should` keys and a warning is logged for each missing.
     """
     __slots__ = ('schema', 'validator', 'extra')
 
-    def __init__(self, schema, allow_extra=True):
+    def __init__(self, schema, allow_extra=True, default_required=False):
         self.schema = schema
         self.extra = REMOVE_EXTRA if allow_extra else PREVENT_EXTRA
-        self.validator = Schema(schema, extra=self.extra)
+        self.validator = Schema(schema, extra=self.extra, required=default_required)
 
 
     def __call__(self, msg):

--- a/protocol_tests/trust_ping/test_trust_ping.py
+++ b/protocol_tests/trust_ping/test_trust_ping.py
@@ -3,7 +3,7 @@
 import asyncio
 
 import pytest
-from voluptuous import Optional
+from voluptuous import Optional, Any
 
 from aries_staticagent import Message, crypto
 from aries_staticagent.mtc import (
@@ -14,6 +14,8 @@ from aries_staticagent.mtc import (
 from reporting import meta
 from ..schema import MessageSchema
 
+TYPE = "https://didcomm.org/trust_ping/1.0/ping"
+ALT_TYPE = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping"
 
 @pytest.mark.asyncio
 @meta(protocol='trust_ping', version='0.1',
@@ -22,7 +24,7 @@ async def test_trust_ping_with_response_requested_true(connection):
     """Test that subject responds to trust pings."""
 
     expected_trust_pong_schema = MessageSchema({
-        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response",
+        "@type": Any(TYPE, ALT_TYPE),
         "@id": str,
         "~thread": {"thid": str},
         Optional("~timing"): {
@@ -33,7 +35,7 @@ async def test_trust_ping_with_response_requested_true(connection):
     })
 
     trust_ping = Message({
-        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping",
+        "@type": TYPE,
         # "@id" is added by the staticagent lib
         "response_requested": True
     })
@@ -62,7 +64,7 @@ async def test_trust_ping_with_response_requested_true(connection):
 async def test_trust_ping_sender(backchannel, connection):
     """Test that subject sends a trust ping."""
     expected_trust_ping_schema = MessageSchema({
-        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping",
+        "@type": Any(TYPE, ALT_TYPE),
         "@id": str,
         Optional("~timing"): {
             Optional("out_time"): str,
@@ -83,7 +85,7 @@ async def test_trust_ping_sender(backchannel, connection):
     assert msg.mtc.recipient == connection.verkey_b58
 
     await connection.send_async({
-        "@type": "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response",
+        "@type": TYPE,
         "~thread": {"thid": msg.id},
     })
 

--- a/protocol_tests/trust_ping/test_trust_ping.py
+++ b/protocol_tests/trust_ping/test_trust_ping.py
@@ -13,9 +13,10 @@ from aries_staticagent.mtc import (
 
 from reporting import meta
 from ..schema import MessageSchema
+from .. import Suite
 
-TYPE = "https://didcomm.org/trust_ping/1.0/ping"
-ALT_TYPE = "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping"
+TYPE = Suite.TYPE_PREFIX + "trust_ping/1.0/ping"
+ALT_TYPE = Suite.ALT_TYPE_PREFIX + "trust_ping/1.0/ping"
 
 @pytest.mark.asyncio
 @meta(protocol='trust_ping', version='0.1',


### PR DESCRIPTION
Summary of changes:

 1. Two new cases to test both main flows in the out-of-band protocol.
	 *  The sender flow --  I create an invitation and you use it
	 * The receiver flow -- You create an invitation and I use it
 2. Support for the out-of-band handshake reuse protocol.
	 * This includes a new message handler to accept and respond  appropriately
3. Support for the did-exchange protocol.
	* You will now be able to complete a did-exchange flow between the AUT and the suite.
	* There is no new test case that explicitly completes this flow, but it is used within the OOB protocol test if specified in the AUT's `handshake_protocol` list. 
 4. Support for sending messages with `https://didcomm.org/` in their `@type` field instead of `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/`
	 * Receiving a message with `did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/` is still supported however.

**NOTES:**
 - Request attach handling is not supported quite yet.
 - During the receiver flow, we only handle the first supported handshake protocol. If that one fails, we don’t retry with the next one.







