### PR TITLE
Send connection response after signing it

### DIFF
--- a/protocol_tests/connection/test_connection.py
+++ b/protocol_tests/connection/test_connection.py
@@ -202,6 +202,8 @@ async def _oob_sender_flow(config, backchannel, temporary_channel):
             info = request.get_connection_info()
             conn.update(**info._asdict())
 
+            await conn.send_async(response)
+
         # If the agent wants to do a did exchange
         elif msg['@type'] == (DidExchangeRequest.TYPE or DidExchangeRequest.ALT_TYPE):
 


### PR DESCRIPTION
There is a current problem in the OOB sender test flow, if a `/connections` type message is being used to create a connection. When the suite receives the `/connection/request` message,  it properly creates a response and signs it, but never send it back. A connection flow will not be completed if the signed response is not received by the sender. This change will fix that and the connection will now be completed.