### PR TITLE
Pin python packages to specific versions in order to fix ledger build…

### DIFF
--- a/ledger/dockerfile
+++ b/ledger/dockerfile
@@ -34,18 +34,22 @@ RUN echo "deb https://repo.sovrin.org/deb xenial $indy_stream" >> /etc/apt/sourc
 
 RUN useradd -ms /bin/bash -u $uid indy
 
-ARG indy_plenum_ver=1.9.1~dev856
-ARG indy_node_ver=1.9.1~dev1043
+ARG indy_plenum_ver=1.12.1~dev989
+ARG indy_node_ver=1.12.1~dev1172
 ARG python3_indy_crypto_ver=0.4.5
 ARG indy_crypto_ver=0.4.5
+ARG python3_pyzmq_ver=18.1.0
 
 RUN apt-get update -y && apt-get install -y \
-        python3-pyzmq=17.0.0 \
+        python3-pyzmq=${python3_pyzmq_ver} \
+        python3-indy-crypto=${python3_indy_crypto_ver} \
         indy-plenum=${indy_plenum_ver} \
         indy-plenum=${indy_plenum_ver} \
         indy-node=${indy_node_ver} \
-        python3-indy-crypto=${python3_indy_crypto_ver} \
         libindy-crypto=${indy_crypto_ver} \
+        python3-orderedset=2.0 \
+        python3-psutil=5.4.3 \
+        python3-pympler=0.5 \
         vim
 
 RUN echo "[supervisord]\n\


### PR DESCRIPTION
Pin python packages to specific versions in order to fix ledger build break.
This was reported in the issue about the docker-compose build break.

Signed-off-by: Keith Smith <bksmith@us.ibm.com>